### PR TITLE
MapTool routing, traffic-manager lane tracking, and annotation tooling

### DIFF
--- a/vico/env.py
+++ b/vico/env.py
@@ -27,7 +27,6 @@ from .tools.constants import ASSETS_PATH, LIGHTS, ENV_OTHER_METADATA
 from .tools.utils import *
 from .modules import *
 
-from .agents.keystroke_counter import KeyCode, KeystrokeCounter
 from .agents import get_agent_cls as _default_get_agent_cls
 
 class VicoEnv:

--- a/vico/env.py
+++ b/vico/env.py
@@ -297,6 +297,15 @@ class VicoEnv:
 
 		self.traffic_manager.init_post_scene_build()
 
+		self.map_tool = MapTool(
+			scene_name=self.scene_name,
+			pose=None,
+			place_metadata=self.place_metadata,
+			building_metadata=self.building_metadata,
+			bus=self.traffic_manager.bus,
+			logger=gs.logger,
+		)
+
 		# forward pass
 		if self.enable_gt_segmentation:
 			# to make sure color is consistent across runs
@@ -921,6 +930,51 @@ class VicoEnv:
 			agent.play_animation(name=action['arg1'])
 		elif action['type'] == 'wait':
 			return
+		elif action['type'] == 'query_map_tool':
+			if agent.robot.base_state == AvatarState.SLEEPING:
+				agent.robot.base_state = AvatarState.STANDING
+			info = self.agent_infos[agent_id]
+			agent_pos = self.config['agent_poses'][agent_id][:3]
+			outdoor_pos = (
+				self.config['agent_poses'][agent_id][:3]
+				if info['current_building'] == 'open space'
+				else info['outdoor_pose'][:3]
+			)
+			arg1 = action['arg1']
+			if arg1 == 'query_place':
+				answer = self.map_tool.query_place(action['arg2'])
+			elif arg1 == 'query_nearby':
+				answer = self.map_tool.query_nearby(action['arg2'], action['arg3'])
+			elif arg1 == 'query_route':
+				answer = self.map_tool.query_route(outdoor_pos, goal_place=action['arg2'], curr_time=self.curr_time)
+			elif arg1 == 'query_grid_map':
+				answer = self.map_tool.query_grid_map()
+			elif arg1 == 'query_grid_map_image':
+				answer = self.map_tool.get_grid_map_image(
+					circle_coords=action['arg2'],
+					route_coords=action['arg3'],
+					agent_coords=[outdoor_pos],
+					target_coords=[action['arg3'][-1]],
+				)
+			elif arg1 == 'query_refine_route':
+				answer = self.map_tool.refine_route(
+					route=action['arg4'],
+					curr_time=self.curr_time,
+					circle_coords=action['arg2'],
+					route_coords=action['arg3'],
+					agent_coords=[outdoor_pos],
+					target_coords=[action['arg3'][-1]],
+				)
+			else:
+				gs.logger.warning(f"Unknown query_map_tool arg1: {arg1!r}; ignored.")
+				return
+			deleted = self.events.add(
+				type="app message", pos=agent_pos, r=1, content=answer,
+				priority=random.randint(0, 100),
+				subject=self.agent_names[agent_id], predicate="get", object="app response",
+			)
+			for subject in deleted:
+				self.agents[self.agent_names.index(subject)].robot.action_status = ActionStatus.FAIL
 		else:
 			raise NotImplementedError(f"agent action type {action['type']} is not supported")
 

--- a/vico/modules/Amap.py
+++ b/vico/modules/Amap.py
@@ -1,0 +1,803 @@
+import ast
+import os
+import random
+import copy
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+import json
+import numpy as np
+import pickle
+import re
+from enum import Enum
+import time
+import math
+import heapq
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.patches import Circle
+from PIL import Image
+import argparse
+
+from ..tools.road_annotation.visualize_osm_roads import draw_roads
+from ..tools.utils import get_assets_dir
+
+if __name__ != "__main__" :
+    from ..tools.utils import *
+    from . import *
+
+def is_point_enclosed_Amap(grid, point, resolution, min_x, min_y, nx, ny):
+    from collections import deque
+
+    i = int((point[0] - min_x) / resolution)
+    j = int((point[1] - min_y) / resolution)
+
+    if i < 0 or i >= nx or j < 0 or j >= ny:
+        # print("Point is out of bounds")
+        return True, (i, j) # not valid
+
+    if grid[i, j] == 1:
+        # print("Point is inside an obstacle")
+        return True, (i, j) # not valid
+    else:
+        return False, (i, j)
+
+    visited = np.zeros_like(grid, dtype=bool)
+    queue = deque()
+    queue.append((i, j))
+    visited[i, j] = True
+
+    directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+
+    while queue:
+        x, y = queue.popleft()
+        if x == 0 or x == nx - 1 or y == 0 or y == ny - 1:
+            # print("Point is not enclosed")
+            return False, (i, j)
+        for dx, dy in directions:
+            nx_ = x + dx
+            ny_ = y + dy
+            if 0 <= nx_ < nx and 0 <= ny_ < ny:
+                if not visited[nx_, ny_] and grid[nx_, ny_] == 0:
+                    visited[nx_, ny_] = True
+                    queue.append((nx_, ny_))
+    # print("Point is enclosed")
+    return True, (i, j)
+
+@dataclass
+class Waypoints:
+    id: int
+    name: str | None = None
+    location: list[float, float] | None = None
+    belong: str | None = None
+    predecessor: list = field(default_factory=list)
+    successor: list = field(default_factory=list)
+    property: dict = field(default_factory=dict)
+
+    def is_a_bus_stop(self):
+        return "bus_stop_id" in self.property
+    
+@dataclass
+class RouteNode:
+    location: list[float, float] | None = None
+    transit: str | None = None
+    eta: datetime | None = None
+
+    def to_dict(self):
+        return {
+            "location": self.location,
+            "transit": self.transit,
+            "eta": datetime.strftime(self.eta, '%H:%M:%S')
+        }
+
+class Route:
+    def __init__(self, nodes=None, impossible=False):
+        '''
+        waypoints: list(np.array([int,int]))
+        '''
+        if nodes is None:
+            self.nodes = []
+        else:
+            self.nodes = nodes
+        self.impossible = impossible
+
+    def __getitem__(self, key):
+        if isinstance(key, int):  # Single index
+            return self.nodes[key]
+        elif isinstance(key, slice):  # Slice → return a new Route
+            return Route(self.nodes[key])
+        else:
+            raise TypeError("Invalid argument type.")
+    
+    def __len__(self):
+        return len(self.nodes)
+    
+    def empty(self):
+        return not self.nodes
+    
+    def append(self, node: RouteNode):
+        self.nodes.append(node)
+
+    def extend(self, route):
+        self.nodes.extend(route.nodes)
+
+    def pop(self, idx):
+        self.nodes.pop(idx)
+
+    def reverse(self):
+        self.nodes.reverse()
+
+    def calc_time(self, pose=None):
+        if self.impossible:
+            return 24*60*60-1
+        if pose is not None:
+            ret=np.linalg.norm(np.array(self.nodes[0].location[:2])-np.array(pose[:2]))/(5.0 if self.nodes[0].transit=='bus' else 1.0)
+        else:
+            ret=0
+        for i in range(1, len(self.nodes)):
+            ret+=np.linalg.norm(np.array(self.nodes[i].location[:2])-np.array(self.nodes[i-1].location[:2]))/(5.0 if self.nodes[i].transit=='bus' else 1.0)
+        return ret*2 # for turning
+    
+    def to_dict(self):
+        return [node.to_dict() for node in self.nodes]
+    
+    def simplify(self):
+        new_nodes=[]
+        i=0
+        while i<len(self.nodes):
+            j=len(self.nodes)
+            while j>i:
+                j-=1
+                if np.linalg.norm(np.array(self.nodes[j].location)-np.array(self.nodes[i].location))<=7:
+                    break
+            new_nodes.append(self.nodes[j])
+            i=j+1
+        self.nodes=new_nodes
+    
+def find_next_bus_times(current_stop, current_time, schedule, schedule_reversed):
+    """
+    Given the current stop and time, return the nearest reachable times
+    for each stop (same index across stops), checking both schedule directions.
+    
+    Returns:
+        dict of stop -> arrival time OR None if no buses available.
+    """
+
+    def get_time_from_str(string):
+        return datetime.combine(current_time.date(), datetime.strptime(string, "%H:%M:%S").time())
+
+    def get_next_index(schedule_variant):
+        """Return (index, schedule_variant) of next bus if available, else (None, None)."""
+        arrivals = schedule_variant[current_stop]["departure_times"]
+        for i, t_str in enumerate(arrivals):
+            t = get_time_from_str(t_str)
+            if t >= current_time:
+                return i, schedule_variant
+        return None, None
+
+    # Check forward and reverse
+    idx_fwd, sch_fwd = get_next_index(schedule)
+    idx_rev, sch_rev = get_next_index(schedule_reversed)
+
+    # Pick the earlier valid bus (if both exist)
+    chosen_index, chosen_schedule = None, None
+    if idx_fwd is not None and idx_rev is not None:
+        t_fwd = get_time_from_str(schedule[current_stop]["arrival_times"][idx_fwd])
+        # if t_fwd<current_time:
+        #     if idx_fwd+1<len(schedule[current_stop]["arrival_times"]):
+        #         t_fwd = datetime.strptime(schedule[current_stop]["arrival_times"][idx_fwd+1], "%H:%M:%S").time()
+        #     else:
+        #         t_fwd = None
+        t_rev = get_time_from_str(schedule_reversed[current_stop]["arrival_times"][idx_rev])
+        # if t_rev<current_time:
+        #     if idx_rev+1<len(schedule[current_stop]["arrival_times"]):
+        #         t_rev = datetime.strptime(schedule[current_stop]["arrival_times"][idx_rev+1], "%H:%M:%S").time()
+        #     else:
+        #         t_rev = None
+        if t_fwd <= t_rev:
+            chosen_index, chosen_schedule = idx_fwd, schedule
+        else:
+            chosen_index, chosen_schedule = idx_rev, schedule_reversed
+    elif idx_fwd is not None:
+        chosen_index, chosen_schedule = idx_fwd, schedule
+    elif idx_rev is not None:
+        chosen_index, chosen_schedule = idx_rev, schedule_reversed
+    else:
+        # No buses left today
+        return {stop: None for stop in range(len(schedule))}
+
+    # Build result
+    result = {}
+    for stop, times in enumerate(chosen_schedule):
+        result[stop] = get_time_from_str(times["arrival_times"][chosen_index])
+        if result[stop]<current_time:
+            if stop==current_stop:
+                result[stop]=current_time
+            else:
+                if chosen_schedule==schedule:
+                    result[stop]=get_time_from_str(schedule_reversed[stop]["arrival_times"][chosen_index])
+                else:
+                    result[stop]=get_time_from_str(schedule[stop]["arrival_times"][chosen_index+1])
+
+    return result
+
+
+class Amap:
+    '''walkers only'''
+    def __init__(self, scene_name=None, pose=None, place_metadata=None, building_metadata=None, bus=None, waypoints_dis=7., logger=None):
+        init_time = time.perf_counter()
+        self.scene_name=scene_name
+        self.pose=pose
+        self.covered_length=0.
+        self.place_metadata=deepcopy(place_metadata)
+        self.building_metadata=deepcopy(building_metadata)
+        self.waypoints_dis=waypoints_dis
+
+        with open(f'{get_assets_dir()}/scenes/{scene_name}/raw/center.txt', "r") as file:
+            for line in file:
+                ref_lat, ref_lon = line.strip().split()
+            ref_lat, ref_lon = float(ref_lat), float(ref_lon)
+        self.roads, self.nodes = pickle.load(open(f"{get_assets_dir()}/scenes/{scene_name}/road_data/roads.pkl", 'rb'))
+        # Paths
+        img_path = f"{get_assets_dir()}/scenes/{self.scene_name}/global.png"
+        if not os.path.exists(img_path):
+            raise FileNotFoundError(f"Aerial image not found: {img_path}")
+        self.global_image = Image.open(img_path).convert("RGB")
+
+        obstacle_grid_save = pickle.load(open(f"{get_assets_dir()}/scenes/{scene_name}/obstacle_grid.pkl", 'rb'))
+        self.obstacle_grid = obstacle_grid_save["grid"]
+        self.obstacle_grid_parameters = obstacle_grid_save["parameters"]
+
+        self.waypoints = []
+        self.road2waypoint_ids = {}
+        self.spawn_waypoints()
+
+        self.logger = logger
+        self.grid_map = None
+        self.clipped_grid_map = None
+        init_time = time.perf_counter() - init_time
+        if self.logger is not None:
+            self.logger.info(f"Amap initialized in {init_time}s")
+        else:
+            print(f"Amap initialized in {init_time}s")
+        
+    def reset(self, pose):
+        self.pose=pose
+        self.covered_length=0.
+
+    def is_point_invalid(self, point, lim=None):
+        if lim is None:
+            lim = self.waypoints_dis
+        return all([is_point_enclosed_Amap(grid=self.obstacle_grid, point=point+shift, resolution=self.obstacle_grid_parameters["resolution"], min_x=self.obstacle_grid_parameters["min_x"], min_y=self.obstacle_grid_parameters["min_y"], nx=self.obstacle_grid_parameters["nx"], ny=self.obstacle_grid_parameters["ny"])[0] for shift in [np.array([i, j]) for i in range(-int(lim),int(lim)+1) for j in range(-int(lim),int(lim)+1)]])
+
+    def spawn_waypoints(self):
+        for node in self.nodes:
+            # if the point is invalid
+            if self.is_point_invalid([self.nodes[node]['x'], self.nodes[node]['y']]): continue
+            # processing node
+            for road in self.nodes[node]["connected_roads"]:
+                if road not in self.road2waypoint_ids:
+                    self.road2waypoint_ids[road]=[]
+                self.road2waypoint_ids[road].append(len(self.waypoints))
+            self.nodes[node]["2wp"]=len(self.waypoints)
+            self.waypoints.append(Waypoints(id=len(self.waypoints), location=[self.nodes[node]['x'], self.nodes[node]['y']], belong=None if not self.nodes[node]["connected_roads"] else self.nodes[node]["connected_roads"][0]))
+        for road in self.roads:
+            # spawn points on road
+            start_x, start_y = road['start']['x'],road['start']['y']
+            end_x, end_y = road['end']['x'],road['end']['y']
+            length = np.linalg.norm(np.array([start_x-end_x, start_y-end_y]))
+            s=self.waypoints_dis
+            # if the start point is invalid
+            if '2wp' not in self.nodes[road['start']['id']]:
+                last_waypoint = None
+            else:
+                last_waypoint=self.waypoints[self.nodes[road['start']['id']]['2wp']]
+            while s<length:
+                p = np.array([start_x, start_y]) - s/length*np.array([start_x-end_x, start_y-end_y])
+                # self.nodes[f"new_node_{len(self.nodes)}"]={"x": p[0], "y": p[1], "connected_roads": road["id"]}
+                if self.is_point_invalid(p):
+                    last_waypoint = None
+                    s+=self.waypoints_dis
+                    continue
+                new_wp=(Waypoints(id=len(self.waypoints), location=p, belong=road["id"]))
+                self.waypoints.append(new_wp)
+                if road['id'] not in self.road2waypoint_ids:
+                    self.road2waypoint_ids[road['id']]=[]
+                self.road2waypoint_ids[road['id']].append(len(self.waypoints))
+                if last_waypoint is not None:
+                    last_waypoint.successor.append(new_wp.id)
+                last_waypoint = new_wp
+                s+=self.waypoints_dis
+            if '2wp' in self.nodes[road['end']['id']] and last_waypoint is not None:
+                last_waypoint.successor.append(self.waypoints[self.nodes[road['end']['id']]['2wp']].id)
+        for waypoint in self.waypoints:
+            for successor in waypoint.successor:
+                self.waypoints[successor].predecessor.append(waypoint.id)
+        # for low-connected waypoints, search its neighbour
+        for idx, waypoint in enumerate(self.waypoints):
+            # if len(waypoint.successor)+len(waypoint.predecessor)>2: continue
+            for jdx, n_wp in enumerate(self.waypoints):
+                if jdx==idx:continue
+                # if len(waypoint.successor)+len(waypoint.predecessor)>2: break
+                if np.linalg.norm(np.array(waypoint.location)-np.array(n_wp.location))<self.waypoints_dis:
+                    self.waypoints[idx].successor.append(jdx)
+                    self.waypoints[jdx].predecessor.append(idx)
+
+    def initiate_transit(self, bus):
+        self.bus_stop_to_waypoint=dict()
+        self.bus=bus
+        for bus_wp_id, r_wp in enumerate(self.bus.route):
+            new_wp=Waypoints(id=len(self.waypoints), location=r_wp, belong=None, predecessor=[], successor=[], property={})
+            self.waypoints.append(new_wp)
+            if bus_wp_id in self.bus.stop_indices:
+                new_wp.property["bus_stop_id"]=self.bus.stop_indices.index(bus_wp_id)
+                self.bus_stop_to_waypoint[self.bus.stop_names[new_wp.property["bus_stop_id"]]]=new_wp.id
+            for jdx, n_wp in enumerate(self.waypoints):
+                if jdx==new_wp.id:continue
+                if np.linalg.norm(np.array(new_wp.location)-np.array(n_wp.location))<self.waypoints_dis:
+                    self.waypoints[new_wp.id].successor.append(jdx)
+                    self.waypoints[jdx].predecessor.append(new_wp.id)
+
+    def get_pose(self):
+        return self.pose
+    
+    def reset_covered_length(self):
+        self.covered_length=0.
+
+    def set_pose(self, pose):
+        self.covered_length+=np.linalg.norm(pose[:2]-self.pose[:2])
+        self.pose=pose
+
+    def query_place(self, place_name):
+        # one place at one time to simulate time cost
+        if place_name not in self.place_metadata: return None
+        knowledge = copy.deepcopy(self.place_metadata[place_name])
+        knowledge["bounding_box"]=self.building_metadata[knowledge['building']]['bounding_box']
+        knowledge_items={place_name: knowledge}
+        return knowledge_items
+    
+    def query_nearby(self, target_pos, threshold=30):
+        assert type(threshold) != str
+        places_list=[]
+        for place in self.place_metadata:
+            if is_near_goal(target_pos[0], target_pos[1], self.building_metadata[self.place_metadata[place]['building']]['bounding_box'], self.place_metadata[place]['location'], threshold=threshold):
+                places_list.append(place)
+        return places_list
+    
+    def get_nearest_waypoints(self, curr_trans):
+        """
+        Find and return several nearest waypoint ids from the given curr_trans.
+        """
+        ret=[]
+        start_wp_id = min(
+            range(len(self.waypoints)),
+            key=lambda i: np.linalg.norm(np.array(self.waypoints[i].location) - np.array(curr_trans[:2]))
+        )
+        min_dis2s = np.linalg.norm(np.array(self.waypoints[start_wp_id].location) - np.array(curr_trans[:2]))
+        for i in range(len(self.waypoints)):
+            if np.linalg.norm(np.array(self.waypoints[i].location) - np.array(curr_trans[:2])) <= min_dis2s+self.waypoints_dis:
+                ret.append(i)
+        return ret
+    
+    def query_route(self, curr_trans, goal_place=None, goal_trans=None, curr_time=datetime.strptime("6:00:00","%H:%M:%S")):
+        """
+        Find a route from current pose to the goal_place using waypoint graph.
+        
+        Args:
+            curr_trans (list | np.ndarray): Current [x, y, ...] position of agent
+            goal_place (str): Name of the destination place
+            goal_trans (list | np.ndarray): The goal position [x, y, ...] in the same coordinate system as curr_trans
+
+        Returns:
+            list[Waypoints]: Ordered list of waypoints from current pose to goal
+        """
+        if not self.waypoints:
+            raise ValueError("No waypoints available. Call spawn_waypoints() first.")
+
+        # Get goal location
+        if goal_place is not None and goal_place not in self.place_metadata:
+            print(f"[Amap.query_route] Unknown place: {goal_place!r}; returning None so the caller can handle it.")
+            return None
+
+        if goal_place is not None:
+            goal_bbox = self.building_metadata[self.place_metadata[goal_place]['building']]['bounding_box']
+            goal_pos = self.place_metadata[goal_place]['location'][:2]  # [x, y]
+        else:
+            goal_bbox = None
+            goal_pos = goal_trans
+        curr_trans=copy.deepcopy(curr_trans)
+        if goal_pos[0]>500 or goal_pos[1]>500:
+            goal_pos[0], goal_pos[1]=goal_pos[0]-1000, goal_pos[1]-1000
+        if curr_trans[0]>500 or curr_trans[1]>500:
+            curr_trans[0], curr_trans[1]=curr_trans[0]-1000, curr_trans[1]-1000
+
+        # 1. Find nearest waypoint to current pose
+        start_wp_id = min(
+            range(len(self.waypoints)),
+            key=lambda i: np.linalg.norm(np.array(self.waypoints[i].location) - np.array(curr_trans[:2]))
+        )
+        min_dis2s = np.linalg.norm(np.array(self.waypoints[start_wp_id].location) - np.array(curr_trans[:2]))
+
+        # 2. Find nearest waypoint to goal location
+        goal_wp_id = min(
+            range(len(self.waypoints)),
+            key=lambda i: np.linalg.norm(np.array(self.waypoints[i].location) - np.array(goal_pos))
+        )
+        min_dis2t = np.linalg.norm(np.array(self.waypoints[goal_wp_id].location) - np.array(goal_pos))
+
+        # 3. Pathfinding: Dijkstra (or BFS if uniform cost) over waypoint graph
+        # Using Dijkstra with distance as edge cost
+        inf_time = datetime.combine(curr_time.date(), datetime.strptime("23:59:59", "%H:%M:%S").time())
+        dist = {i: inf_time for i in range(len(self.waypoints))}
+        prev = {i: None for i in range(len(self.waypoints))}
+        heap = []
+        for i in range(len(self.waypoints)):
+            if np.linalg.norm(np.array(self.waypoints[i].location) - np.array(curr_trans[:2])) <= min_dis2s+self.waypoints_dis:
+                dist[i] = curr_time+timedelta(seconds=np.linalg.norm(np.array(self.waypoints[i].location) - np.array(curr_trans[:2])))
+                heapq.heappush(heap, (dist[i], i))
+
+        while heap:
+            d, wp_id = heapq.heappop(heap)
+            if d > dist[wp_id]:
+                continue
+            if wp_id == goal_wp_id:
+                break
+
+            current_wp = self.waypoints[wp_id]
+            potential = current_wp.successor + current_wp.predecessor
+            for succ_id in potential:
+                if succ_id >= len(self.waypoints):
+                    continue
+                succ_wp = self.waypoints[succ_id]
+                cost = np.linalg.norm(
+                    np.array(current_wp.location) - np.array(succ_wp.location)
+                )
+                new_dist = dist[wp_id] + timedelta(seconds=cost)
+                if new_dist < dist[succ_id]:
+                    dist[succ_id] = new_dist
+                    prev[succ_id] = [wp_id, 'walk']
+                    heapq.heappush(heap, (new_dist, succ_id))
+            if current_wp.is_a_bus_stop():
+                next_bus_time=find_next_bus_times(current_wp.property["bus_stop_id"], curr_time, self.bus.schedule, self.bus.schedule_reversed)
+                for i in range(len(self.bus.stop_names)):
+                    bus_wp_id=self.bus_stop_to_waypoint[self.bus.stop_names[i]]
+                    if bus_wp_id == wp_id: continue
+                    new_dist=next_bus_time[i]
+                    if dist[wp_id]<new_dist<dist[bus_wp_id]:
+                        dist[bus_wp_id]=new_dist
+                        prev[bus_wp_id] = [wp_id, 'bus']
+                        heapq.heappush(heap, (new_dist, bus_wp_id))
+
+        # 4. Reconstruct path
+        goal_wp_pair=(dist[goal_wp_id]+timedelta(seconds=min_dis2t), goal_wp_id)
+        for i in range(len(self.waypoints)):
+            if is_near_goal(self.waypoints[i].location[0], self.waypoints[i].location[1], goal_bbox, goal_pos):
+                goal_wp_pair=min((dist[i], i), goal_wp_pair)
+            elif np.linalg.norm(np.array(self.waypoints[i].location) - np.array(goal_pos)) <= min_dis2t+self.waypoints_dis:
+                goal_wp_pair=min((dist[i]+timedelta(seconds=np.linalg.norm(np.array(self.waypoints[i].location) - np.array(goal_pos))), i), goal_wp_pair)
+        if self.logger is not None:
+            self.logger.info(f"found goal_wp_pair is {goal_wp_pair}")
+        else:
+            print(f"found goal_wp_pair is {goal_wp_pair}")
+        if goal_wp_pair[0] >= inf_time:
+            self.logger.warning(f"{self.scene_name}: No path found from {curr_trans[:2]} to {goal_place} at {goal_pos}")
+            return Route(impossible=True)
+        path = Route()
+        curr = goal_wp_pair[1]
+        while curr is not None:
+            if prev[curr] is None:
+                path.append(RouteNode(list(self.waypoints[curr].location), 'walk', dist[curr]))
+                curr = None
+            else:
+                path.append(RouteNode(list(self.waypoints[curr].location), prev[curr][1], dist[curr]))
+                curr = prev[curr][0]
+        path.reverse()
+
+        if not path:
+            self.logger.warning(f"{self.scene_name}: No valid route found from {curr_trans[:2]} to {goal_place} at {goal_pos}")
+            return Route(impossible=True)
+        
+        path.append(RouteNode(list(goal_pos), 'walk', goal_wp_pair[0]))
+        return path
+    
+    def get_connected_waypoints(self, waypoint_id):
+        """
+        Find all waypoints connected to the given waypoint_id via successor/predecessor links.
+        Performs BFS to collect all reachable waypoints in the graph.
+
+        Returns:
+            List[int]: List of waypoint IDs that are connected (including the start).
+        """
+        if waypoint_id >= len(self.waypoints) or waypoint_id < 0:
+            return []
+
+        visited = set()
+        queue = [waypoint_id]
+        visited.add(waypoint_id)
+
+        while queue:
+            current_id = queue.pop(0)
+            current_wp = self.waypoints[current_id]
+
+            # Traverse both successors and predecessors for full connectivity
+            neighbors = current_wp.successor + current_wp.predecessor
+            for neighbor_id in neighbors:
+                if neighbor_id < len(self.waypoints) and neighbor_id not in visited:
+                    visited.add(neighbor_id)
+                    queue.append(neighbor_id)
+
+        return sorted(list(visited))
+    
+    def get_zoomed_scene_metadata(self, x_min, y_min, x_max, y_max):
+        """
+        Return a dict that contains all roads and buildings metadata within the area.
+        """
+        ret_road = dict()
+        ret_building = dict()
+
+        # As for roads
+        for road in self.roads:
+            start_x, start_y = road['start']['x'],road['start']['y']
+            end_x, end_y = road['end']['x'],road['end']['y']
+            if (x_min <= start_x <= x_max and y_min <= start_y <=y_max) or (x_min <= end_x <= x_max and y_min <= end_y <=y_max):
+                ret_road[f"{road['name']} {road['id']}"]={'start': [road['start']['x'], road['start']['y']], 'end': [road['end']['x'], road['end']['y']]}
+
+        # As for buildings
+        for building in self.building_metadata:
+            print(self.building_metadata[building])
+            if building == 'open space':
+                for place in self.building_metadata[building]['places']:
+                    if (x_min <= place['location'][0] <= x_max and y_min <= place['location'][1] <=y_max):
+                        ret_building[place['name']] = place
+            else:
+                p = self.building_metadata[building]['outdoor_xy']
+                if (x_min <= p[0] <= x_max and y_min <= p[1] <=y_max):
+                    ret_building[building]=self.building_metadata[building]
+        
+        return ret_road, ret_building
+    
+    def get_zoomed_scene_image(self, x_min, y_min, x_max, y_max, alpha=1.0):
+        """
+        Return a zoomed-in part of the whole scene image with road annotations
+        as a PIL.Image.Image object.
+
+        Args:
+            scene_name (str): Scene name (e.g., "newyork", "detroit").
+            x_min, y_min, x_max, y_max (float): Bounding box coordinates in world units
+                (matching the coordinate extent used when displaying the image, e.g. [-512, 512]).
+            ref_lat, ref_lon (float, optional): Reference latitude and longitude for projection.
+
+        Returns:
+            PIL.Image.Image: Cropped and annotated subimage.
+        """
+        # Paths
+        img_path = f"{get_assets_dir()}/scenes/{self.scene_name}/global.png"
+
+        # Check assets
+        if not os.path.exists(img_path):
+            raise FileNotFoundError(f"Aerial image not found: {img_path}")
+
+        # Load aerial image
+        img = self.global_image
+        width, height = img.size
+        world_min, world_max = -512, 512
+
+        # Create a Matplotlib figure with the zoomed-in extent
+        fig, ax = plt.subplots(figsize=(6, 6))
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(y_min, y_max)
+        ax.set_aspect("equal")
+
+        # Display the cropped portion of the aerial image
+        ax.imshow(
+            img,
+            extent=[world_min, world_max, world_min, world_max],
+            origin="upper"
+        )
+
+        # Draw roads
+        draw_roads(self.roads, alpha=alpha)
+
+        color_dict = {'primary': 'red', 'secondary': 'orangered', 'tertiary': 'orange', 'residential': 'gold', 
+              'cycleway':'green', 'pedestrian': 'blue', 'footway': 'deepskyblue', 'service': 'peru', 
+              'unclassified': 'm', 'steps': 'blue', 'elevator':'violet', 'living_street':'pink', 'construction': 'orchid'}
+
+        legend_handles = [mpatches.Patch(color=color, label=road_type) for road_type, color in color_dict.items()]
+
+        ax.legend(handles=legend_handles, title="Road Types", loc='upper left', bbox_to_anchor=(1.0, 1.0), borderaxespad=0, fontsize='small', title_fontsize='medium')
+        plt.tight_layout(pad=0., rect=[0, 0, 1, 1])
+
+        # Turn off axes and layout
+        # ax.axis("off")
+        # plt.tight_layout(pad=0)
+
+        # Render figure to a PIL Image
+        fig.canvas.draw()
+        buf = np.asarray(fig.canvas.buffer_rgba())
+        h, w, _ = buf.shape
+        zoomed_img = buf[:, :, :3]  # drop alpha
+        zoomed_img = Image.fromarray(zoomed_img)
+
+        plt.close(fig)
+        return zoomed_img
+    
+    def query_grid_map(self):
+        if getattr(self, "grid_map", None) is not None:
+            return self.grid_map
+        # Define grid size and coordinate range
+        grid_size = 50
+        cell_size = 20
+        coord_min, coord_max = -490, 490
+
+        # Initialize with open space ('.')
+        grid_map = np.full((grid_size, grid_size), '.', dtype=str)
+
+        # Precompute coordinate offset
+        offset = coord_min // cell_size  # = 49 for [-495, 495]
+
+        # Iterate through coordinates
+        for x in range(coord_min, coord_max + 1, cell_size):
+            for y in range(coord_min, coord_max + 1, cell_size):
+                i = (y // cell_size) - offset
+                j = (x // cell_size) - offset
+                # Skip if out of bounds
+                if not (0 <= i < grid_size and 0 <= j < grid_size):
+                    continue
+                # Mark obstacle
+                if self.is_point_invalid([x, y], lim=10):
+                    grid_map[i, j] = 'X'
+
+        self.grid_map = grid_map.tolist()
+        return self.grid_map
+    
+    def get_grid_map_image(self, route_coords=None, circle_coords=None, agent_coords=None, target_coords=None, new_route_coords=None):
+        return self.visualize_grid_with_objects(grid=self.obstacle_grid, resolution=self.obstacle_grid_parameters["resolution"], min_x=self.obstacle_grid_parameters["min_x"], min_y=self.obstacle_grid_parameters["min_y"], route_coords=route_coords, circle_coords=circle_coords, agent_coords=agent_coords, target_coords=target_coords, new_route_coords=new_route_coords)
+
+    def visualize_grid_with_objects(self, grid, route_coords=None, circle_coords=None, agent_coords=None, target_coords=None, new_route_coords=None,
+                                resolution=1.0, min_x=0, min_y=0):
+        """
+        Visualize occupancy grid with multiple types of external coordinates.
+
+        Args:
+            grid (np.ndarray): 2D array, 1 for obstacle (black), 0 for free (white)
+            route_coords (list[(x, y)]): sequence of points forming a route
+            circle_coords (list[(x, y)]): centers of circle markers
+            agent_coords (list[(x, y)]): isolated points
+            target_coords (list[(x, y)]): isolated points
+            resolution (float): meters per grid cell
+            min_x, min_y (float): world coordinates of grid[0, 0]
+        """
+        if self.clipped_grid_map is None:
+            grid = deepcopy(grid)
+            grid = grid[int((-400 - min_x)/resolution):int((400 - min_x)/resolution), int((-400 - min_y)/resolution):int((400 - min_y)/resolution)].T
+            self.clipped_grid_map = grid
+            min_x, min_y = -400, -400
+            h, w = grid.shape
+        else:
+            grid = self.clipped_grid_map
+            min_x, min_y = -400, -400
+            h, w = grid.shape
+
+        # --- Plot background grid ---
+        fig, ax = plt.subplots(figsize=(8, 8))
+        ax.imshow(grid, cmap='gray_r', origin='lower',
+                extent=[min_x, min_x + w * resolution,
+                        min_y, min_y + h * resolution])
+
+        # Helper: test if a coordinate is in free space
+        def is_free(x, y):
+            gx = int((x - min_x) / resolution)
+            gy = int((y - min_y) / resolution)
+            if gx < 0 or gx >= w or gy < 0 or gy >= h:
+                return False
+            return grid[gy, gx] == 0
+
+        # --- 2️⃣ Circle-like coordinates ---
+        if circle_coords is not None:
+            for (x, y) in circle_coords:
+                # if is_free(x, y):
+                circle = Circle((x, y), radius=20, edgecolor='red',
+                                facecolor='red', linewidth=1.5)
+                ax.add_patch(circle)
+
+        # --- 1️⃣ Route-like coordinates ---
+        if route_coords is not None and len(route_coords) > 0:
+            # self.logger.info(f"getting grid image, route_coords are {route_coords}")
+            route_coords = np.array([p for p in route_coords if is_free(p[0], p[1])])
+            if len(route_coords) > 0:
+                ax.plot(route_coords[:, 0], route_coords[:, 1], c='blue', linewidth=1.5)
+                ax.scatter(route_coords[:, 0], route_coords[:, 1],
+                        s=12, c='blue', edgecolors='k', linewidths=0.3, zorder=3)
+
+        # --- 1️⃣ New Route-like coordinates ---
+        if new_route_coords is not None and len(new_route_coords) > 0:
+            new_route_coords = np.array([p for p in new_route_coords if is_free(p[0], p[1])])
+            if len(new_route_coords) > 0:
+                ax.plot(new_route_coords[:, 0], new_route_coords[:, 1], c='orange', linewidth=1.5)
+                ax.scatter(new_route_coords[:, 0], new_route_coords[:, 1],
+                        s=12, c='orange', edgecolors='k', linewidths=0.3, zorder=3)
+
+        # --- 3️⃣ Point-like coordinates ---
+        if agent_coords is not None:
+            pts = np.array([p for p in agent_coords if is_free(p[0], p[1])])
+            if len(pts) > 0:
+                ax.scatter(pts[:, 0], pts[:, 1], s=12, c='green', zorder=3)
+
+        # --- 3️⃣ Point-like coordinates ---
+        if target_coords is not None:
+            pts = np.array([p for p in target_coords if is_free(p[0], p[1])])
+            if len(pts) > 0:
+                ax.scatter(pts[:, 0], pts[:, 1], s=12, c='purple', zorder=3)
+
+        # --- Display setup ---
+        ax.set_xlabel("X (world units)")
+        ax.set_ylabel("Y (world units)")
+        ax.set_title("Occupancy Grid with External Elements")
+        ax.grid(True, linestyle=':', alpha=0.4)
+        ax.axis('equal')
+        plt.tight_layout(pad=0., rect=[0, 0, 1, 1])
+
+        fig.canvas.draw()
+        buf = np.asarray(fig.canvas.buffer_rgba())
+        h, w, _ = buf.shape
+        img = buf[:, :, :3]  # drop alpha
+        if img.shape[0]>800:
+            img = img[::2, ::2, :]
+        print(img.shape)
+        plt.close(fig)
+        return img.tolist()
+        img = Image.fromarray(img)
+
+        return img
+    
+    def refine_route(self, route, curr_time, route_coords=None, circle_coords=None, agent_coords=None, target_coords=None):
+        ret=Route()
+        for wp in route:
+            nwp_loc = self.waypoints[self.get_nearest_waypoints(wp)[0]].location
+            if len(ret)==0:
+                ret.append(RouteNode(list(nwp_loc), 'walk', datetime.combine(curr_time.date(), datetime.strptime("23:59:59", "%H:%M:%S").time())))
+            else:
+                new_route=self.query_route(ret[-1].location, goal_place=None, goal_trans=nwp_loc, curr_time=curr_time)
+                if new_route.impossible == 0: ret.extend(new_route)
+        if target_coords is not None:
+            if len(ret)==0:
+                ret.append(RouteNode(list(target_coords[0]), 'walk', datetime.combine(curr_time.date(), datetime.strptime("23:59:59", "%H:%M:%S").time())))
+            else:
+                new_route=self.query_route(ret[-1].location, goal_place=None, goal_trans=target_coords[0], curr_time=curr_time)
+                if new_route.impossible == 0: ret.extend(new_route)
+        ret.simplify()
+        return {"refined_route": ret, "grid_map_image": self.get_grid_map_image(route_coords=route_coords, circle_coords=circle_coords, agent_coords=agent_coords, target_coords=target_coords, new_route_coords=[list(wp.location) for wp in ret])}
+
+
+if __name__ == "__main__" :
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scene", '-s', type=str, required=True)
+    args = parser.parse_args()
+    scene_dir = f"{get_assets_dir()}/scenes/{args.scene}"
+    if not os.path.exists(f"{scene_dir}/road_data/road_data.pkl"):
+        print(f"{scene_dir}/road_data/road_data.pkl not exist!")
+        exit()
+    with open(f"{scene_dir}/raw/center.txt", "r") as file:
+        for line in file:
+            ref_lat, ref_lon = line.strip().split()
+        ref_lat, ref_lon = float(ref_lat), float(ref_lon)
+    building_metadata = json.load(open(os.path.join(f"{scene_dir}/agents_num_15", "building_metadata.json"), 'r'))
+    place_metadata = json.load(open(os.path.join(f"{scene_dir}/agents_num_15", "place_metadata.json"), 'r'))
+    amap=Amap(scene_name=args.scene, building_metadata=building_metadata, place_metadata=place_metadata)
+    wps=[wp.location for wp in amap.waypoints]
+    xs, ys = zip(*wps)
+    plt.figure(figsize=(10, 6))
+    plt.plot(xs, ys, 'bo', markersize=3)
+    n_wps=amap.get_nearest_waypoints([285.16, -196.96])
+    c_wps=set()
+    for wp in n_wps:
+        c_wps.update(amap.get_connected_waypoints(wp))
+    c_wps=[wp.location for wp in amap.waypoints if wp.id in c_wps]
+    c_xs, c_ys = zip(*c_wps)
+    plt.plot(c_xs, c_ys, 'ro', markersize=3)
+    plt.title(f'Amap Waypoints Visualization - {args.scene}')
+    plt.xlabel('X Coordinate')
+    plt.ylabel('Y Coordinate')
+    plt.grid()
+    plt.axis('equal')
+    plt.show()

--- a/vico/modules/MapTool.py
+++ b/vico/modules/MapTool.py
@@ -253,9 +253,9 @@ class MapTool:
         self.clipped_grid_map = None
         init_time = time.perf_counter() - init_time
         if self.logger is not None:
-            self.logger.info(f"Amap initialized in {init_time}s")
+            self.logger.info(f"MapTool initialized in {init_time}s")
         else:
-            print(f"Amap initialized in {init_time}s")
+            print(f"MapTool initialized in {init_time}s")
         
     def reset(self, pose):
         self.pose=pose
@@ -264,7 +264,7 @@ class MapTool:
     def is_point_invalid(self, point, lim=None):
         if lim is None:
             lim = self.waypoints_dis
-        return all([is_point_enclosed_Amap(grid=self.obstacle_grid, point=point+shift, resolution=self.obstacle_grid_parameters["resolution"], min_x=self.obstacle_grid_parameters["min_x"], min_y=self.obstacle_grid_parameters["min_y"], nx=self.obstacle_grid_parameters["nx"], ny=self.obstacle_grid_parameters["ny"])[0] for shift in [np.array([i, j]) for i in range(-int(lim),int(lim)+1) for j in range(-int(lim),int(lim)+1)]])
+        return all([is_point_enclosed_MapTool(grid=self.obstacle_grid, point=point+shift, resolution=self.obstacle_grid_parameters["resolution"], min_x=self.obstacle_grid_parameters["min_x"], min_y=self.obstacle_grid_parameters["min_y"], nx=self.obstacle_grid_parameters["nx"], ny=self.obstacle_grid_parameters["ny"])[0] for shift in [np.array([i, j]) for i in range(-int(lim),int(lim)+1) for j in range(-int(lim),int(lim)+1)]])
 
     def spawn_waypoints(self):
         for node in self.nodes:
@@ -392,7 +392,7 @@ class MapTool:
 
         # Get goal location
         if goal_place is not None and goal_place not in self.place_metadata:
-            print(f"[Amap.query_route] Unknown place: {goal_place!r}; returning None so the caller can handle it.")
+            print(f"[MapTool.query_route] Unknown place: {goal_place!r}; returning None so the caller can handle it.")
             return None
 
         if goal_place is not None:
@@ -779,19 +779,19 @@ if __name__ == "__main__" :
         ref_lat, ref_lon = float(ref_lat), float(ref_lon)
     building_metadata = json.load(open(os.path.join(f"{scene_dir}/agents_num_15", "building_metadata.json"), 'r'))
     place_metadata = json.load(open(os.path.join(f"{scene_dir}/agents_num_15", "place_metadata.json"), 'r'))
-    amap=Amap(scene_name=args.scene, building_metadata=building_metadata, place_metadata=place_metadata)
-    wps=[wp.location for wp in amap.waypoints]
+    map_tool=MapTool(scene_name=args.scene, building_metadata=building_metadata, place_metadata=place_metadata)
+    wps=[wp.location for wp in map_tool.waypoints]
     xs, ys = zip(*wps)
     plt.figure(figsize=(10, 6))
     plt.plot(xs, ys, 'bo', markersize=3)
-    n_wps=amap.get_nearest_waypoints([285.16, -196.96])
+    n_wps=map_tool.get_nearest_waypoints([285.16, -196.96])
     c_wps=set()
     for wp in n_wps:
-        c_wps.update(amap.get_connected_waypoints(wp))
-    c_wps=[wp.location for wp in amap.waypoints if wp.id in c_wps]
+        c_wps.update(map_tool.get_connected_waypoints(wp))
+    c_wps=[wp.location for wp in map_tool.waypoints if wp.id in c_wps]
     c_xs, c_ys = zip(*c_wps)
     plt.plot(c_xs, c_ys, 'ro', markersize=3)
-    plt.title(f'Amap Waypoints Visualization - {args.scene}')
+    plt.title(f'MapTool Waypoints Visualization - {args.scene}')
     plt.xlabel('X Coordinate')
     plt.ylabel('Y Coordinate')
     plt.grid()

--- a/vico/modules/MapTool.py
+++ b/vico/modules/MapTool.py
@@ -20,7 +20,7 @@ from PIL import Image
 import argparse
 
 from ..tools.road_annotation.visualize_osm_roads import draw_roads
-from ..tools.utils import get_assets_dir
+from ..tools.constants import ASSETS_PATH
 
 if __name__ != "__main__" :
     from ..tools.utils import *
@@ -233,14 +233,14 @@ class MapTool:
         self.building_metadata=deepcopy(building_metadata)
         self.waypoints_dis=waypoints_dis
 
-        self.roads, self.nodes = pickle.load(open(f"{get_assets_dir()}/scenes/{scene_name}/road_data/roads.pkl", 'rb'))
+        self.roads, self.nodes = pickle.load(open(f"{ASSETS_PATH}/scenes/{scene_name}/road_data/roads.pkl", 'rb'))
         # Paths
-        img_path = f"{get_assets_dir()}/scenes/{self.scene_name}/global.png"
+        img_path = f"{ASSETS_PATH}/scenes/{self.scene_name}/global.png"
         if not os.path.exists(img_path):
             raise FileNotFoundError(f"Aerial image not found: {img_path}")
         self.global_image = Image.open(img_path).convert("RGB")
 
-        obstacle_grid_save = pickle.load(open(f"{get_assets_dir()}/scenes/{scene_name}/obstacle_grid.pkl", 'rb'))
+        obstacle_grid_save = pickle.load(open(f"{ASSETS_PATH}/scenes/{scene_name}/obstacle_grid.pkl", 'rb'))
         self.obstacle_grid = obstacle_grid_save["grid"]
         self.obstacle_grid_parameters = obstacle_grid_save["parameters"]
 
@@ -567,7 +567,7 @@ class MapTool:
             PIL.Image.Image: Cropped and annotated subimage.
         """
         # Paths
-        img_path = f"{get_assets_dir()}/scenes/{self.scene_name}/global.png"
+        img_path = f"{ASSETS_PATH}/scenes/{self.scene_name}/global.png"
 
         # Check assets
         if not os.path.exists(img_path):
@@ -769,7 +769,7 @@ if __name__ == "__main__" :
     parser = argparse.ArgumentParser()
     parser.add_argument("--scene", '-s', type=str, required=True)
     args = parser.parse_args()
-    scene_dir = f"{get_assets_dir()}/scenes/{args.scene}"
+    scene_dir = f"{ASSETS_PATH}/scenes/{args.scene}"
     if not os.path.exists(f"{scene_dir}/road_data/road_data.pkl"):
         print(f"{scene_dir}/road_data/road_data.pkl not exist!")
         exit()

--- a/vico/modules/MapTool.py
+++ b/vico/modules/MapTool.py
@@ -233,10 +233,6 @@ class MapTool:
         self.building_metadata=deepcopy(building_metadata)
         self.waypoints_dis=waypoints_dis
 
-        with open(f'{get_assets_dir()}/scenes/{scene_name}/raw/center.txt', "r") as file:
-            for line in file:
-                ref_lat, ref_lon = line.strip().split()
-            ref_lat, ref_lon = float(ref_lat), float(ref_lon)
         self.roads, self.nodes = pickle.load(open(f"{get_assets_dir()}/scenes/{scene_name}/road_data/roads.pkl", 'rb'))
         # Paths
         img_path = f"{get_assets_dir()}/scenes/{self.scene_name}/global.png"

--- a/vico/modules/MapTool.py
+++ b/vico/modules/MapTool.py
@@ -26,7 +26,7 @@ if __name__ != "__main__" :
     from ..tools.utils import *
     from . import *
 
-def is_point_enclosed_Amap(grid, point, resolution, min_x, min_y, nx, ny):
+def is_point_enclosed_MapTool(grid, point, resolution, min_x, min_y, nx, ny):
     from collections import deque
 
     i = int((point[0] - min_x) / resolution)
@@ -222,7 +222,7 @@ def find_next_bus_times(current_stop, current_time, schedule, schedule_reversed)
     return result
 
 
-class Amap:
+class MapTool:
     '''walkers only'''
     def __init__(self, scene_name=None, pose=None, place_metadata=None, building_metadata=None, bus=None, waypoints_dis=7., logger=None):
         init_time = time.perf_counter()

--- a/vico/modules/__init__.py
+++ b/vico/modules/__init__.py
@@ -5,5 +5,5 @@ from .outdoor_objects import *
 from .avatar import *
 from .vehicle import *
 from .traffic_manager import *
-from .Amap import *
+from .MapTool import *
 from .robot import ROBOT_CONTROLLERS, ROBOT_POSITION_OFFSETS, ROBOT_CONFIGS

--- a/vico/modules/__init__.py
+++ b/vico/modules/__init__.py
@@ -5,4 +5,5 @@ from .outdoor_objects import *
 from .avatar import *
 from .vehicle import *
 from .traffic_manager import *
+from .Amap import *
 from .robot import ROBOT_CONTROLLERS, ROBOT_POSITION_OFFSETS, ROBOT_CONFIGS

--- a/vico/modules/traffic_manager/localmap.py
+++ b/vico/modules/traffic_manager/localmap.py
@@ -3,10 +3,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 import math
 import os
+import copy
+from copy import deepcopy
 from pathlib import Path
 import pickle
 import random
 import pyproj
+import argparse
+import json
+from ...tools.utils import get_assets_dir
 
 def cubic_func(t, shape):
     u = shape['aU']+shape['bU']*t+shape['cU']*(t**2)+shape['dU']*(t**3)  # Cubic function for u
@@ -467,16 +472,46 @@ class LocalMap:
                 else:
                     geometry[idx]['type']='unknown'
             # get lane information
-            lanes = [
-                {
-                    'id': int(lane.get('id')), 
-                    'type': lane.get('type'), 
-                    'level': lane.get('level'), 
-                    'width': float(lane.find('width').get('a'))+float(lane.find('roadMark').get('width'))
-                }
-                for lane in road.findall('lanes/laneSection/right/lane')
-            ]
+            lanes=[]
+            for lane in road.findall('lanes/laneSection/right/lane'):
+                lanes.append(
+                    {
+                        'id': -int(lane.get('id'))-1, 
+                        'type': lane.get('type'), 
+                        'level': lane.get('level'), 
+                        'width': float(lane.find('width').get('a'))+float(lane.find('roadMark').get('width')),
+                        'link': {
+                            'predecessor': [],
+                            'successor': []
+                        }
+                    }
+                )
+                assert lanes[-1]['id']==len(lanes)-1
+                if junction!="-1": # according to xodr, only road in junctions has these property
+                    assert lane.find('link/predecessor') is not None
+                    predecessor_id=predecessor.get("elementId")
+                    successor_id=successor.get("elementId")
+                    lanes[-1]['link']={
+                        'predecessor': [{'road_id':predecessor_id, 'lane_id':-int(lane.find('link/predecessor').get('id'))-1}],
+                        'successor': [{'road_id':successor_id, 'lane_id':-int(lane.find('link/successor').get('id'))-1}]
+                    }
+                    
+                    assert self.roads[predecessor_id]['junction']=="-1"
+                    for idx in range(len(self.roads[predecessor_id]['lanes'])):
+                        if self.roads[predecessor_id]['lanes'][idx]['id']==lanes[-1]['link']['predecessor'][0]['lane_id']:
+                            self.roads[predecessor_id]['lanes'][idx]['link']['successor'].append(
+                                {'road_id': id, 'lane_id':lanes[-1]['id']})
+                    assert self.roads[successor_id]['junction']=="-1"
+                    for idx in range(len(self.roads[successor_id]['lanes'])):
+                        if self.roads[successor_id]['lanes'][idx]['id']==lanes[-1]['link']['successor'][0]['lane_id']:
+                            self.roads[successor_id]['lanes'][idx]['link']['predecessor'].append(
+                                {'road_id': id, 'lane_id':lanes[-1]['id']})
+                else:
+                    if lane.find('link/predecessor') is not None: print(id)
+                    assert lane.find('link/predecessor') is None
             lane_offset = float(road.find('lanes/laneOffset').get('a')) if road.find('lanes/laneOffset') is not None else 0.
+
+            # adding road information to self.roads
             self.roads[id]={
                 'name': name, 
                 'length': length, 
@@ -501,6 +536,11 @@ class LocalMap:
                 for conn in junc.findall('connection')
             ]
             self.junctions[id]={'name':name, 'id': id, 'connections': connections}
+
+        self.printable_roads = copy.deepcopy(self.roads)
+        for road in self.printable_roads:
+            self.printable_roads[road]["predecessor"]=self.get_previous_roads(road)
+            self.printable_roads[road]['successor']=self.get_next_roads(road)
         
         self.valid_road=self.cut_branch()
         self.main_roads=[road for road in self.main_roads if road in self.valid_road]
@@ -739,6 +779,19 @@ class LocalMap:
         if not next_roads:
             return None
         return random.choice(next_roads)
+    
+    def get_next_roads_and_lanes(self, road_id, lane_id):
+        '''
+        This function is used to select next roads for vehicles (not for pedestrians currently).
+        '''
+        assert road_id in self.valid_road
+        lane=self.roads[road_id]['lanes'][lane_id]
+        next_roads_and_lanes=[road for road in lane['link']['successor'] if road['road_id'] in self.valid_road]
+        while len(next_roads_and_lanes)==0:
+            lane_id=(lane_id+1)%len(self.roads[road_id]['lanes'])
+            lane=self.roads[road_id]['lanes'][lane_id]
+            next_roads_and_lanes=[road for road in lane['link']['successor'] if road['road_id'] in self.valid_road]
+        return next_roads_and_lanes
         
     def get_junction(self, road_id):
         return self.roads[road_id]['junction']
@@ -751,3 +804,20 @@ class PedestrianMap(BaseMap):
     def get_pedestrian_paths(self):
         """Return all paths designated for pedestrians."""
         return self.pedestrian_paths
+    
+
+if __name__ == "__main__" :
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scene", '-s', type=str, required=True)
+    args = parser.parse_args()
+    scene_dir = f"{get_assets_dir()}/scenes/{args.scene}"
+    if not os.path.exists(f"{scene_dir}/road_data/road_data.xodr"):
+        print(f"{scene_dir}/road_data/road_data.xodr not exist!")
+        exit()
+    with open(f"{scene_dir}/raw/center.txt", "r") as file:
+        for line in file:
+            ref_lat, ref_lon = line.strip().split()
+        ref_lat, ref_lon = float(ref_lat), float(ref_lon)
+    local_map=LocalMap(file_path=f"{scene_dir}/road_data/road_data.xodr", terrain_height_path=None, ref_lat=ref_lat, ref_lon=ref_lon)
+    with open("local_map_instance.json", "w") as f:
+        json.dump(local_map.printable_roads, f, indent=2)

--- a/vico/modules/traffic_manager/simple_vehicle.py
+++ b/vico/modules/traffic_manager/simple_vehicle.py
@@ -4,12 +4,13 @@ class SimpleVehicle:
     '''
     used in traffic manager
     '''
-    def __init__(self, id, init_pos, init_rot, init_road, init_s, std_speed=5.):
+    def __init__(self, id, init_pos, init_rot, init_road, init_s, init_lane, std_speed=5.):
         self.id = id
         self.pos = init_pos
         self.rot = init_rot
         self.road = init_road
         self.s = init_s
+        self.lane = init_lane
         self.action = {"type": "stop"}
         self.std_speed = std_speed
 
@@ -19,12 +20,13 @@ class SimpleVehicle:
     def get_pos(self):
         return self.pos
 
-    def set_loc(self, road, s):
+    def set_loc(self, road, s, lane=0):
         self.road=road
         self.s=s
+        self.lane=lane
 
     def get_loc(self):
-        return self.road, self.s
+        return self.road, self.s, self.lane
     
     def set_rot(self, rot):
         self.rot=rot

--- a/vico/modules/traffic_manager/traffic_manager.py
+++ b/vico/modules/traffic_manager/traffic_manager.py
@@ -5,6 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 import matplotlib.image as mpimg
+import json
 
 from .. import *
 
@@ -14,12 +15,25 @@ from .simple_agent import *
 from ...tools.utils import get_assets_dir
 
 class TrafficManager:
-    def __init__(self, env, scene_name, vehicle_number=0, pedestrian_number=0, dry_run=False, enable_tm_debug=False, logger=None, debug=False):
+    def __init__(self, env, scene_name, vehicle_number=0, pedestrian_number=0, dry_run=False, enable_tm_debug=False, config_path=None, logger=None, debug=False):
         self.env = env
         self.logger = logger
         self.debug = debug
         self.enable_tm_debug = enable_tm_debug
         self.dry_run = dry_run
+        self.config_path=config_path
+        self.config=None
+        # Optional spawn config (JSON). Schema:
+        #   {
+        #     "pedestrians": [{"road_id": str, "s": float}, ...],
+        #     "vehicles":    [{"road_id": str, "s": float, "lane_id": int, "model": str}, ...]
+        #   }
+        # When provided, vehicle_number/pedestrian_number are overridden by len().
+        if self.config_path is not None:
+            with open(self.config_path, "r") as f:
+                self.config=json.load(f)
+            pedestrian_number=len(self.config['pedestrians'])
+            vehicle_number=len(self.config['vehicles'])
         if pedestrian_number>0 or vehicle_number>0:
             self.enable_traffic=True
         else:
@@ -39,6 +53,8 @@ class TrafficManager:
             self.vehicles_on_road = {}
             for road_id in self.map.get_roads().keys():
                 self.vehicles_on_road[road_id]=list()
+                for lane in self.map.roads[road_id]['lanes']:
+                    self.vehicles_on_road[road_id].append(list())
         else:
             self.map = None
             self.sampled_roads = []
@@ -66,7 +82,7 @@ class TrafficManager:
             self.add_vehicle(
                 vehicle=self.env.add_vehicle(
                     name=f"auto_vehicle_{i}",
-                    vehicle_asset_path="cars/Car/OldCar.glb",
+                    vehicle_asset_path="cars/Car/OldCar.glb" if self.config is None else f"cars/Car/{self.config['vehicles'][i]['model']}",
                     ego_view_options={
                         "res": (self.env.resolution, self.env.resolution),
                         "fov": 90,
@@ -150,11 +166,17 @@ class TrafficManager:
     # Function to create pedestrians
     def create_pedestrians(self, pedestrian_number):
         for _ in range(pedestrian_number):
-            road_id = random.choice(list(self.map.pedestrian_main_roads.keys()))
-            start_s = random.uniform(0, self.map.get_length(road_id))
-            pos = self.map.get_pos(road_id = road_id, s = start_s, lane_id=-1)
-            rot = self.map.get_rot(road_id = road_id, s = start_s)
-            avatar=SimpleVehicle(id = _, init_pos = pos, init_rot = rot, init_road = road_id, init_s = start_s, std_speed = random.uniform(0.8, 1.4))
+            if self.config is None:
+                road_id = random.choice(list(self.map.pedestrian_main_roads.keys()))
+                start_s = random.uniform(0, self.map.get_length(road_id))
+                pos = self.map.get_pos(road_id = road_id, s = start_s, lane_id=-1)
+                rot = self.map.get_rot(road_id = road_id, s = start_s)
+            else:
+                road_id = self.config['pedestrians'][_]['road_id']
+                start_s = self.config['pedestrians'][_]['s']
+                pos = self.map.get_pos(road_id = road_id, s = start_s, lane_id=-1)
+                rot = self.map.get_rot(road_id = road_id, s = start_s)
+            avatar=SimpleVehicle(id = _, init_pos = pos, init_rot = rot, init_road = road_id, init_s = start_s, init_lane=-1, std_speed = random.uniform(0.8, 1.4))
             self.simple_avatars.append(avatar)
         
     # Function to move pedestrians
@@ -162,44 +184,44 @@ class TrafficManager:
         for ped_id, ped in enumerate(self.simple_avatars):
             if self.dry_run==False and self.avatars[ped_id].avatar.action_status()=="ONGOING":
                 continue
-            road_id, s = ped.get_loc()
+            road_id, s, lane_id = ped.get_loc()
             road_length = self.map.get_length(road_id)
-            scaler = self.map.calc_lane_scaler(road_id, s, lane_id=-1, direction=1 if ped.std_speed>0 else 2)
+            scaler = self.map.calc_lane_scaler(road_id, s, lane_id=lane_id, direction=1 if ped.std_speed>0 else 2)
             s += ped.std_speed * dt / scaler  # Update position along the road
-            ped.set_loc(road_id, s)
+            ped.set_loc(road_id, s, lane_id)
             #print(f"Pedestrian road_id: {road_id}, s: {ped['s']}, road_length: {road_length}")
 
             
             if s >= road_length:  # Check if pedestrian exceeds road length
                 next_road_id = self.map.get_next_road(road_id, valid=True, pedestrian_only=True)
                 if next_road_id:
-                    if next_road_id in self.junction_hazzard:
+                    if next_road_id in self.junction_hazard:
                         pass
                     else:
                         # self.logger.info(f"Pedestrian moving to next road: {next_road_id}, s={ped['s']}")
-                        ped.set_loc(next_road_id, 0.)  # Move to the next road
+                        ped.set_loc(next_road_id, 0., lane_id)  # Move to the next road
                 else:
                     # self.logger.info(f"No next road for pedestrian on road {road_id}, s={ped['s']}")
-                    ped.set_loc(road_id, road_length - 0.01)  # Stop at the end of the current road
+                    ped.set_loc(road_id, road_length - 0.01, lane_id)  # Stop at the end of the current road
                     ped.std_speed = -ped.std_speed # And turn around and walk back
 
             
             if s < 0:  # Check if pedestrian exceeds road length
                 prev_road_id = self.map.get_previous_road(road_id, valid=True, pedestrian_only=True)
                 if prev_road_id:
-                    if prev_road_id in self.junction_hazzard:
+                    if prev_road_id in self.junction_hazard:
                         pass
                     else:
                         # self.logger.info(f"Pedestrian moving to next road: {next_road_id}, s={ped['s']}")
-                        ped.set_loc(prev_road_id, self.map.get_length(prev_road_id) - 0.01)  # Move to the next road
+                        ped.set_loc(prev_road_id, self.map.get_length(prev_road_id) - 0.01, lane_id)  # Move to the next road
                 else:
                     # self.logger.info(f"No next road for pedestrian on road {road_id}, s={ped['s']}")
-                    ped.set_loc(road_id, 0.)  # Stop at the end of the current road
+                    ped.set_loc(road_id, 0., lane_id)  # Stop at the end of the current road
                     ped.std_speed = -ped.std_speed # And turn around and walk back
     
             # Update pedestrian position
             try:
-                ped.set_pos(self.map.get_pos(ped.road, ped.s, lane_id=-1, direction=1 if ped.std_speed>0 else 2, std=0.4))
+                ped.set_pos(self.map.get_pos(ped.road, ped.s, lane_id=lane_id, direction=1 if ped.std_speed>0 else 2, std=0.4))
                 ped.set_rot(self.map.get_rot(ped.road, ped.s, direction=1 if ped.std_speed>0 else 2))
             except AssertionError as e:
                 print(f"Error in get_pos: road_id={ped.road}, s={ped.s}, road_length={road_length}")
@@ -226,13 +248,22 @@ class TrafficManager:
         '''
         Firstly create a simple vehicle object, which is an abstract in traffic manager. Then env will call add_vehicle() to create an auto vehicle in the simulator.
         '''
-        sampled_road = random.sample(self.sampled_roads, 1)[0]
-        self.sampled_roads.remove(sampled_road)
-        pos = self.map.get_pos(road_id = sampled_road, s = 0.)
-        rot = self.map.get_rot(road_id = sampled_road, s = 0.)
-        simple_vehicle=SimpleVehicle(id = len(self.simple_vehicles), init_pos = pos, init_rot = rot, init_road = sampled_road, init_s = 0.)
+        if self.config == None:
+            sampled_road = random.sample(self.sampled_roads, 1)[0]
+            self.sampled_roads.remove(sampled_road)
+            init_s = 0.
+            init_lane = 0
+            pos = self.map.get_pos(road_id = sampled_road, s = init_s, lane_id=init_lane)
+            rot = self.map.get_rot(road_id = sampled_road, s = init_s)
+        else:
+            sampled_road = self.config['vehicles'][len(self.simple_vehicles)]['road_id']
+            init_s = self.config['vehicles'][len(self.simple_vehicles)]['s']
+            init_lane = self.config['vehicles'][len(self.simple_vehicles)]['lane_id']
+            pos = self.map.get_pos(road_id = sampled_road, s = init_s, lane_id=init_lane)
+            rot = self.map.get_rot(road_id = sampled_road, s = init_s)
+        simple_vehicle=SimpleVehicle(id = len(self.simple_vehicles), init_pos = pos, init_rot = rot, init_road = sampled_road, init_s = init_s, init_lane=init_lane)
         self.simple_vehicles.append(simple_vehicle)
-        self.vehicles_on_road[sampled_road].append((0., simple_vehicle.id))
+        self.vehicles_on_road[sampled_road][init_lane].append((init_s, simple_vehicle.id))
         return simple_vehicle
 
     def add_vehicle(self, vehicle, simple_vehicle, debug=False, logger=None):
@@ -250,82 +281,96 @@ class TrafficManager:
         self.avatars.append(avatar)
     
     def plan(self):
-        self.junction_hazzard=dict()
+        self.junction_hazard=dict()
         # filling each junctions with vehicles already in it
         for rid, road in enumerate(self.vehicles_on_road):
             junc_id = self.map.get_junction(road)
             if len(self.vehicles_on_road[road])==0 or junc_id=="-1": continue
-            sorted_vehicles = sorted(self.vehicles_on_road[road])
-            for s, vehicle_id in sorted_vehicles:
-                assert junc_id not in self.junction_hazzard
-                self.junction_hazzard[junc_id]=vehicle_id
+            for lane_id in range(len(self.vehicles_on_road[road])):
+                sorted_vehicles = sorted(self.vehicles_on_road[road][lane_id])
+                for s, vehicle_id in sorted_vehicles:
+                    assert (junc_id not in self.junction_hazard or self.junction_hazard[junc_id]==road)
+                    self.junction_hazard[junc_id]=road
         for i, ped in enumerate(self.simple_avatars):
-            road_id, s = ped.get_loc()
+            road_id, s, lane_id = ped.get_loc()
             junc_id = self.map.get_junction(road_id)
             if junc_id=="-1": continue
-            if junc_id not in self.junction_hazzard:
-                self.junction_hazzard[junc_id]=f"ped_{i}"
+            if junc_id not in self.junction_hazard:
+                self.junction_hazard[junc_id]=road_id
         for rid, road in enumerate(self.vehicles_on_road):
-            if len(self.vehicles_on_road[road])==0: continue
-            sorted_vehicles = sorted(self.vehicles_on_road[road])
-            for vid, sorted_vehicle in enumerate(sorted_vehicles):
-                s, vehicle_id = sorted_vehicle
-                # speed = np.random.normal(loc=self.uniform_speed, scale=0.1)
-                speed = self.uniform_speed
-                if self.dry_run==False:
-                    if self.vehicles[vehicle_id].spare()==False:
-                        self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'arg1': "vehicle is still moving or turning."}
-                        continue
-                # halt if there is a collision ahead
-                if vid+1<len(sorted_vehicles):
-                    if s+speed+self.min_dis>=sorted_vehicles[vid+1][0]:
-                        self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'arg1': f"collision with {sorted_vehicles[vid+1][1]} ahead on the same road"}
-                        continue
-                # if the vehicle is going into the next road...
-                if s+speed>self.map.get_length(road):
-                    next_road=self.smart_get_next_road(road)
-                    if next_road is None:
-                        self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'arg1': "no road ahead"}
-                        continue
-                    # print(f"road: {road}, next: {next_road}")
-                    assert next_road!=road
-                    junc_id = self.map.get_junction(next_road)
-                    if junc_id!="-1":
-                        if junc_id in self.junction_hazzard:
-                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, "arg1": f"junction_hazzard with {self.junction_hazzard[junc_id]}"}
+            for lane_id, vehicles_in_lane in enumerate(self.vehicles_on_road[road]):
+                if len(vehicles_in_lane)==0: continue
+                sorted_vehicles = sorted(vehicles_in_lane)
+                for vid, sorted_vehicle in enumerate(sorted_vehicles):
+                    s, vehicle_id = sorted_vehicle
+                    # speed = np.random.normal(loc=self.uniform_speed, scale=0.1)
+                    speed = self.uniform_speed
+                    if self.dry_run==False:
+                        if self.vehicles[vehicle_id].spare()==False:
+                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, 'arg1': "vehicle is still moving or turning."}
                             continue
-                        self.junction_hazzard[junc_id]=vehicle_id
-                        self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'move_forward', 'arg1': self.map.get_length(road)-s, 'next_road': next_road}
-                        # no need of checking vehicles in next road since its in a junction
-                        continue
-                    else:
-                        tmp_list=sorted(self.vehicles_on_road[next_road])# nearest vehicle on the next road
-                        if len(tmp_list)>0 and tmp_list[0][0]<self.min_dis:
-                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, "arg1": f"{tmp_list[0][1]} on next road"}
+                    # halt if there is a collision ahead
+                    if vid+1<len(sorted_vehicles):
+                        if s+speed+self.min_dis>=sorted_vehicles[vid+1][0]:
+                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, 'arg1': f"collision with {sorted_vehicles[vid+1][1]} ahead on the same road"}
+                            continue
+                    if vid+1==len(sorted_vehicles):
+                        if s+speed+self.min_dis>=self.map.get_length(road)+self.get_dis_to_nearest_vehicle(road, lane_id, self.min_dis+speed):
+                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, 'arg1': f"collision with some vehicle ahead on some next road"}
+                            continue
+                    # if the vehicle is going into the next road...
+                    if s+speed>self.map.get_length(road):
+                        next_road_and_lane=self.smart_get_next_road(road, lane_id=lane_id)
+                        if next_road_and_lane is None:
+                            # if lane_id==0:print(road, lane_id)
+                            assert lane_id!=0 # cant be on the 0 lane...
+                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, 'arg1': "no road ahead"}
+                            continue
+                        next_road, next_lane = next_road_and_lane['road_id'], next_road_and_lane['lane_id']
+                        assert next_road!=road
+                        junc_id = self.map.get_junction(next_road)
+                        if junc_id!="-1":
+                            if junc_id in self.junction_hazard and self.junction_hazard[junc_id]!=next_road:
+                                self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, "arg1": f"junction_hazard with road {self.junction_hazard[junc_id]}"}
+                                continue
+                            tmp_list=sorted(self.vehicles_on_road[next_road][next_lane])# nearest vehicle on the next road
+                            if len(tmp_list)>0 and tmp_list[0][0]<self.min_dis:
+                                self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, "arg1": f"{tmp_list[0][1]} on next road in junction."}
+                            else:
+                                self.junction_hazard[junc_id]=next_road
+                                self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'move_forward', 'arg1': self.map.get_length(road)-s, 'next_road': next_road, 'next_lane': next_lane}
+                            continue
                         else:
-                            self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'move_forward', 'arg1': self.map.get_length(road)-s, 'next_road': next_road}
-                        continue
-                self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'move_forward', 'arg1': speed, 'next_road': road}
+                            tmp_list=sorted(self.vehicles_on_road[next_road][next_lane])# nearest vehicle on the next road
+                            if len(tmp_list)>0 and tmp_list[0][0]<self.min_dis:
+                                self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'stop', 'next_road': road, 'next_lane': lane_id, "arg1": f"{tmp_list[0][1]} on next road"}
+                            else:
+                                self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'move_forward', 'arg1': self.map.get_length(road)-s, 'next_road': next_road, 'next_lane': next_lane}
+                            continue
+                    self.vehicle_action[vehicle_id]={'id': vehicle_id, 'type': 'move_forward', 'arg1': speed, 'next_road': road, 'next_lane': lane_id}
 
     def act(self):
         # update self.vehicles_on_road
         for road_id in self.map.get_roads().keys():
-            self.vehicles_on_road[road_id]=list()
+            for lane_id in range(len(self.vehicles_on_road[road_id])):
+                self.vehicles_on_road[road_id][lane_id]=list()
         # update vehicles
         for i in range(self.vehicle_number):
             next_road_id=self.vehicle_action[i]['next_road']
-            road_id, s=self.simple_vehicles[i].get_loc()
+            next_lane_id=self.vehicle_action[i]['next_lane']
+            road_id, s, lane_id=self.simple_vehicles[i].get_loc()
             # print(f"road_id: {road_id}, s: {s}")
             if self.vehicle_action[i]['type']=='move_forward':
                 s+=self.vehicle_action[i]['arg1']
                 if road_id != next_road_id:
                     s=0.
-                self.simple_vehicles[i].set_loc(next_road_id,s)
+                    lane_id=next_lane_id
+                self.simple_vehicles[i].set_loc(next_road_id, s, lane_id)
             if self.vehicle_action[i]['type']=='stop':
                 pass
-            self.vehicles_on_road[next_road_id].append((s, i))
+            self.vehicles_on_road[next_road_id][lane_id].append((s, i))
             # print(f"next_road_id: {next_road_id}, s: {s}")
-            self.simple_vehicles[i].set_pos(self.map.get_pos(next_road_id,s))
+            self.simple_vehicles[i].set_pos(self.map.get_pos(next_road_id,s, lane_id))
             self.simple_vehicles[i].set_rot(self.map.get_rot(next_road_id,s))
     
     def schedule(self):
@@ -339,8 +384,8 @@ class TrafficManager:
     def step(self):
         if self.enable_traffic:
             self.schedule()
-        # if self.enable_tm_debug:
-        #     self.logger.info(self.vehicle_action)
+        if self.enable_tm_debug:
+            self.logger.info(self.vehicle_action)
         for vehicle in self.vehicles:
             vehicle.step()
         for avatar in self.avatars:
@@ -352,26 +397,47 @@ class TrafficManager:
     def get_pedestrians_pos(self):
         return [ped.get_pos() for ped in self.simple_avatars]
     
-    def is_full(self, road):
-        tmp_list=sorted(self.vehicles_on_road[road])# nearest vehicle on the next road
+    def is_full(self, road_id, lane_id):
+        '''
+        return True if the road is full of vehicles
+        '''
+        tmp_list=sorted(self.vehicles_on_road[road_id][lane_id])# nearest vehicle on the next road
         if len(tmp_list)>0 and tmp_list[0][0]<self.min_dis:
             return True
         else:
             return False
         
-    def smart_get_next_road(self, road):
-        next_roads = self.map.get_next_roads(road, valid=True)
-        next_roads = [next_road for next_road in next_roads if not self.is_full(road)]
-        if len(next_roads)==0:
-            return self.map.get_next_road(road)
-        if len(next_roads)==1:
-            return next_roads[0]
-        if len(next_roads)>1:
-            next_roads = [next_road for next_road in next_roads if len([nnr for nnr in self.map.get_next_roads(next_road, valid=True) if not self.is_full(nnr)])>0]
-            if len(next_roads)>0:
-                return random.choice(next_roads)
+    def get_dis_to_nearest_vehicle(self, road_id, lane_id, min_dis):
+        '''
+        get the distance to the nearest vehicle ahead the endpoint of the current road and lane.
+        '''
+        if min_dis<0:return 0
+        next_roads_and_lanes = self.map.get_next_roads_and_lanes(road_id, lane_id)
+        ret=min_dis
+        for next_road_and_lane in next_roads_and_lanes:
+            next_road_id, next_lane_id=next_road_and_lane['road_id'], next_road_and_lane['lane_id']
+            tmp_list=sorted(self.vehicles_on_road[next_road_id][next_lane_id])
+            if len(tmp_list)>0:
+                ret=min(ret, tmp_list[0][0])
             else:
-                return self.map.get_next_road(road)
+                ret=min(ret, self.get_dis_to_nearest_vehicle(next_road_id, next_lane_id, min_dis-self.map.get_length(next_road_id)))+self.map.get_length(next_road_id)
+        return ret
+        
+    def smart_get_next_road(self, road_id, lane_id):
+        next_roads_and_lanes = self.map.get_next_roads_and_lanes(road_id, lane_id)
+        if len(next_roads_and_lanes)==0:
+            return None
+        next_roads_and_lanes = [next_road_and_lane for next_road_and_lane in next_roads_and_lanes if not self.is_full(next_road_and_lane['road_id'], next_road_and_lane['lane_id'])]
+        if len(next_roads_and_lanes)==0:
+            return self.map.get_next_roads_and_lanes(road_id, lane_id)[0]
+        if len(next_roads_and_lanes)==1:
+            return next_roads_and_lanes[0]
+        if len(next_roads_and_lanes)>1:
+            next_roads_and_lanes = [next_road_and_lane for next_road_and_lane in next_roads_and_lanes if len([nnr for nnr in self.map.get_next_roads_and_lanes(next_road_and_lane['road_id'], next_road_and_lane['lane_id']) if not self.is_full(nnr['road_id'], nnr['lane_id'])])>0]
+            if len(next_roads_and_lanes)>0:
+                return random.choice(next_roads_and_lanes)
+            else:
+                return self.map.get_next_roads_and_lanes(road_id, lane_id)[0]
 
     def init_post_scene_build(self):
         bus_pose = self.bus.update_at_time(self.env.curr_time)
@@ -420,18 +486,19 @@ if __name__ == "__main__" :
     parser = argparse.ArgumentParser()
     parser.add_argument("--scene", '-s', type=str, required=True)
     args = parser.parse_args()
-    if not os.path.exists(f"{get_assets_dir()}/scenes/{args.scene}/road_data/road_data.xodr"):
-        print(f"{get_assets_dir()}/scenes/{args.scene}/road_data/road_data.xodr not exist!")
+    scene_dir = f"{get_assets_dir()}/scenes/{args.scene}"
+    if not os.path.exists(f"{scene_dir}/road_data/road_data.xodr"):
+        print(f"{scene_dir}/road_data/road_data.xodr not exist!")
         exit()
-    with open(f'assets/scenes/{args.scene}/raw/center.txt', "r") as file:
+    with open(f"{scene_dir}/raw/center.txt", "r") as file:
         for line in file:
             ref_lat, ref_lon = line.strip().split()
         ref_lat, ref_lon = float(ref_lat), float(ref_lon)
-    local_map=LocalMap(file_path=f"{get_assets_dir()}/scenes/{args.scene}/road_data/road_data.xodr", terrain_height_path=None, ref_lat=ref_lat, ref_lon=ref_lon)
+    local_map=LocalMap(file_path=f"{scene_dir}/road_data/road_data.xodr", terrain_height_path=None, ref_lat=ref_lat, ref_lon=ref_lon)
     traffic_manager = TrafficManager(None, args.scene, vehicle_number=60, dry_run=True, pedestrian_number=60)
 
     fig, ax = plt.subplots(figsize=(10, 6))
-    aerial_view=mpimg.imread(f"{get_assets_dir()}/scenes/{args.scene}/global.png")
+    aerial_view=mpimg.imread(f"{scene_dir}/global.png")
     plt.imshow(aerial_view, extent=[-512, 512, -512, 512])# left, right, bottom, top
     ax.set_xlim(0, 10)
     ax.set_ylim(0, 6)

--- a/vico/tools/misc/take_avatar_photos.py
+++ b/vico/tools/misc/take_avatar_photos.py
@@ -141,9 +141,14 @@ def main():
 
             depth_threshold = 10.0
             mask = depth <= depth_threshold
-            rgb = rgb.copy()
-            rgb[~mask] = 0
-            rgba = rgb[:, :, [2, 1, 0]]
+
+            # Enhance brightness by 20%, clamped to valid range
+            rgb_bright = np.clip(rgb.astype(np.float32) * 1.2, 0, 255).astype(np.uint8)
+
+            # Build BGRA image: transparent background, opaque foreground
+            bgr = rgb_bright[:, :, [2, 1, 0]]
+            alpha = (mask * 255).astype(np.uint8)
+            rgba = np.dstack([bgr, alpha])
 
             relative_img_save_path = os.path.join(img_save_dir, f"{char_name}_{idx}_rgb.png")
             success = cv2.imwrite(relative_img_save_path, rgba)

--- a/vico/tools/road_annotation/create_opdr.py
+++ b/vico/tools/road_annotation/create_opdr.py
@@ -1,0 +1,62 @@
+import json
+import os
+import pickle
+import osmnx as ox
+from shapely.strtree import STRtree
+from shapely.geometry import Point, Polygon
+import math
+import requests
+from tqdm import tqdm
+import numpy as np
+from scipy.spatial import cKDTree
+import matplotlib.pyplot as plt
+from PIL import Image
+import argparse
+import time
+
+import carla
+from pathlib import Path
+
+def create_opdr(scene_name):
+    if os.path.exists(f"ViCo/assets/scenes/{scene_name}/road_data/road_data.osm"):
+        with open(f"ViCo/assets/scenes/{scene_name}/road_data/road_data.osm","r", encoding="utf-8") as file:
+            osm_data=file.read()
+    else:
+        assert 0 and "osm data not exist"
+    try:
+        # Define the desired settings. In this case, default values.
+        settings = carla.Osm2OdrSettings()
+        settings.proj_string='+proj=merc'
+        # Set OSM road types to export to OpenDRIVE
+        settings.set_osm_way_types(["motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link", "unclassified", "residential"])
+        # Convert to .xodr
+        xodr_data = carla.Osm2Odr.convert(osm_data, settings)
+        with open(f"ViCo/assets/scenes/{scene_name}/road_data/road_data.xodr","w", encoding='utf-8') as file:
+            file.write(xodr_data)
+    except Exception as e:
+        pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scene", "-s", type=str, required=True)
+    args = parser.parse_args()
+    if os.path.exists(f"ViCo/assets/scenes/{args.scene}/road_data"):
+        print("Scene exists")
+    else:
+        print(f"Scene not exist: ViCo/assets/scenes/{args.scene}/road_data")
+        exit()
+    create_opdr(scene_name=args.scene)
+
+    # Set up the plot area
+    plt.figure(figsize=(8, 8))
+    plt.xlim(-500, 500)
+    plt.ylim(-500, 500)
+    plt.gca().set_aspect('equal', adjustable='box')
+    plt.grid()
+
+    # Show the plot
+    plt.title(f'Roads with Width - {args.scene}')
+    plt.xlabel('X-axis')
+    plt.ylabel('Y-axis')
+    plt.show()

--- a/vico/tools/road_annotation/road_stats.py
+++ b/vico/tools/road_annotation/road_stats.py
@@ -1,0 +1,48 @@
+import os
+import json
+from collections import defaultdict, Counter
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+
+sns.set(style="whitegrid", font_scale=1.1)
+
+root_path = "ViCo/assets/scenes"
+stats = {}
+
+for scene in tqdm(os.listdir(root_path)):
+    try:
+        with open(os.path.join(root_path, scene, "road_data/road_data.xodr")) as f:
+            stats[scene] = {}
+            road_xodr = f.read()
+            stats[scene]["road_counts"] = road_xodr.count('<road name')
+            stats[scene]["junc_counts"] = road_xodr.count('<junction name')
+    except:
+        continue
+
+scene_names = sorted(stats.keys())[:35]
+
+# Plot 1: Buildings per Scene
+Roads = [stats[scene]["road_counts"] for scene in scene_names]
+print(f"avg roads: {sum(Roads)/len(Roads)}")
+df_Roads = pd.DataFrame({'Scene': scene_names, 'Roads': Roads})
+
+plt.figure(figsize=(18, 6))
+sns.barplot(data=df_Roads, x='Scene', y='Roads', color='#4C72B0')
+plt.xticks(rotation=45, ha='right')
+plt.title("Number of Annotated Roads per Scene", weight='bold')
+plt.tight_layout()
+plt.show()
+
+# Plot 2: Junctions per Scene
+junctions = [stats[scene]["junc_counts"] for scene in scene_names]
+print(f"avg junctions: {sum(junctions)/len(junctions)}")
+df_junctions = pd.DataFrame({'Scene': scene_names, 'Junctions': junctions})
+
+plt.figure(figsize=(18, 6))
+sns.barplot(data=df_junctions, x='Scene', y='Junctions', color='#55A868')
+plt.xticks(rotation=45, ha='right')
+plt.title("Number of Annotated Junctions per Scene", weight='bold')
+plt.tight_layout()
+plt.show()

--- a/vico/tools/road_annotation/visualize_osm_roads.py
+++ b/vico/tools/road_annotation/visualize_osm_roads.py
@@ -1,0 +1,183 @@
+import json
+import os
+import pickle
+import math
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import matplotlib.image as mpimg
+from PIL import Image
+import argparse
+import time
+
+from pathlib import Path
+
+from ..utils import get_assets_dir
+
+
+def lat_lon_to_xy(lat, lon, ref_lat, ref_lon):
+    earth_radius = 6378137  # in meters
+    meters_per_degree_lat = 111139  # Approximate meters per degree latitude
+    
+    # Calculate meters per degree longitude based on reference latitude
+    meters_per_degree_lon = 111139 * math.cos(math.radians(ref_lat))
+    
+    # Convert lat/lon to x/y
+    x = (lon - ref_lon) * meters_per_degree_lon
+    y = (lat - ref_lat) * meters_per_degree_lat
+    
+    return [x, y]
+
+def draw_line_segment(start, end, width, color='white', alpha=1.0):
+    # Calculate the direction vector from start to end
+    direction = np.array(end) - np.array(start)
+    length = np.linalg.norm(direction)
+    
+    # Normalize the direction vector
+    if length == 0:
+        return  # Avoid division by zero if start and end are the same
+    direction /= length
+    
+    # Calculate perpendicular vector
+    perp_direction = np.array([-direction[1], direction[0]])  # Rotate 90 degrees
+    
+    # Calculate offset for width
+    offset = (width / 2) * perp_direction
+    
+    # Define the four corners of the line segment rectangle
+    corner1 = start + offset
+    corner2 = start - offset
+    corner3 = end - offset
+    corner4 = end + offset
+    
+    # Create a polygon (rectangle) representing the line segment with width
+    line_segment = np.array([corner1, corner2, corner3, corner4])
+    
+    # Plotting
+    plt.fill(line_segment[:, 0], line_segment[:, 1], color=color, alpha=alpha)  # Draw filled rectangle for width
+    plt.plot([start[0], end[0]], [start[1], end[1]], color='black', linewidth=1)  # Draw main line
+
+def draw_roads(roads, alpha=1.0):
+    color_dict={'primary': 'red', 'secondary': 'orangered', 'tertiary': 'orange', 'residential': 'gold', 'cycleway':'green', 'pedestrian': 'blue', 'footway': 'deepskyblue', 'service': 'peru', 'unclassified': 'm', 'steps': 'blue', 'elevator':'violet', 'living_street':'pink', 'construction': 'orchid'}
+    for road in roads:
+        # print(road)
+        highway = road['highway']
+        color = 'grey'
+        if highway in color_dict:
+            color = color_dict[highway]
+        # color = {'yes': 'red', 'no': 'blue'}[road['oneway']]
+        start_x, start_y = road['start']['x'],road['start']['y']
+        end_x, end_y = road['end']['x'],road['end']['y']
+        # print(road['width'])
+        # assert not isinstance(road['width'],str)
+        draw_line_segment([start_x, start_y], [end_x, end_y] ,road['width'], color, alpha=alpha)
+    # for node in nodes.values():
+    #     plt.scatter(node['x'], node['y'], color='lime', s=2)
+
+def get_zoomed_scene_image(scene_name, x_min, y_min, x_max, y_max, ref_lat=None, ref_lon=None, alpha=1.0):
+    """
+    Return a zoomed-in part of the whole scene image with road annotations
+    as a PIL.Image.Image object.
+
+    Args:
+        scene_name (str): Scene name (e.g., "newyork", "detroit").
+        x_min, y_min, x_max, y_max (float): Bounding box coordinates in world units
+            (matching the coordinate extent used when displaying the image, e.g. [-512, 512]).
+        ref_lat, ref_lon (float, optional): Reference latitude and longitude for projection.
+
+    Returns:
+        PIL.Image.Image: Cropped and annotated subimage.
+    """
+    # Paths
+    img_path = f"{get_assets_dir()}/scenes/{scene_name}/global.png"
+    roads_path = f"{get_assets_dir()}/scenes/{scene_name}/road_data/roads.pkl"
+
+    # Check assets
+    if not os.path.exists(img_path):
+        raise FileNotFoundError(f"Aerial image not found: {img_path}")
+    if not os.path.exists(roads_path):
+        raise FileNotFoundError(f"Road data not found: {roads_path}")
+
+    # Load aerial image
+    img = Image.open(img_path).convert("RGB")
+    width, height = img.size
+    world_min, world_max = -512, 512
+
+    # Load road data
+    roads, nodes = pickle.load(open(roads_path, "rb"))
+
+    # Create a Matplotlib figure with the zoomed-in extent
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+    ax.set_aspect("equal")
+
+    # Display the cropped portion of the aerial image
+    ax.imshow(
+        img,
+        extent=[world_min, world_max, world_min, world_max],
+        origin="upper"
+    )
+
+    # Draw roads
+    draw_roads(roads, alpha=alpha)
+
+    # Turn off axes and layout
+    ax.axis("off")
+    plt.tight_layout(pad=0)
+
+    # Render figure to a PIL Image
+    fig.canvas.draw()
+    zoomed_img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+    zoomed_img = zoomed_img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    zoomed_img = Image.fromarray(zoomed_img)
+
+    plt.close(fig)
+    return zoomed_img
+
+
+
+# python tools/fetch_osm_roads.py -s newyork --ref_lat 40.748998486718186 --ref_lon -73.9882893780644 --radius 400
+# python tools/fetch_osm_roads.py -s detroit --ref_lat 42.33165461030516 --ref_lon -83.0480662316049 --radius 400
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scene", "-s", type=str, required=True)
+    # parser.add_argument("--radius", type=float, required=True)
+    args = parser.parse_args()
+    if os.path.exists(f"{get_assets_dir()}/scenes/{args.scene}"):
+        print("Scene exists")
+        Path(f"{get_assets_dir()}/scenes/{args.scene}/road_data").mkdir(parents=True, exist_ok=True)
+        with open(f"{get_assets_dir()}/scenes/{args.scene}/raw/center.txt", "r") as f:
+            ref_lat, ref_lon=f.readline().split()
+            args.ref_lat, args.ref_lon=float(ref_lat), float(ref_lon)
+            print(f"retrieved coordinates from raw file. lat: {args.ref_lat}, lon: {args.ref_lon}")
+    else:
+        print(f"Scene not exist: {get_assets_dir()}/scenes/{args.scene}")
+        exit()
+
+    # Set up the plot area
+    plt.figure(figsize=(8, 8))
+    aerial_view=mpimg.imread(f"{get_assets_dir()}/scenes/{args.scene}/global.png")
+    plt.imshow(aerial_view, extent=[-512, 512, -512, 512])# left, right, bottom, top
+    plt.xlim(-400, 400)
+    plt.ylim(-400, 400)
+    plt.gca().set_aspect('equal', adjustable='box')
+    # plt.grid()
+
+    roads, nodes = pickle.load(open(f"{get_assets_dir()}/scenes/{args.scene}/road_data/roads.pkl", 'rb'))
+    draw_roads(roads)
+    # draw_roads(roads, nodes, args.ref_lat, args.ref_lon)
+
+    color_dict = {'primary': 'red', 'secondary': 'orangered', 'tertiary': 'orange', 'residential': 'gold', 
+              'cycleway':'green', 'pedestrian': 'blue', 'footway': 'deepskyblue', 'service': 'peru', 
+              'unclassified': 'm', 'steps': 'blue', 'elevator':'violet', 'living_street':'pink', 'construction': 'orchid'}
+
+    legend_handles = [mpatches.Patch(color=color, label=road_type) for road_type, color in color_dict.items()]
+
+    plt.legend(handles=legend_handles, title="Road Types", loc='upper left', fontsize='small', title_fontsize='medium')
+
+    # Show the plot
+    # plt.title(f'Roads with Width - {args.scene}')
+    # plt.xlabel('X-axis')
+    # plt.ylabel('Y-axis')
+    plt.show()


### PR DESCRIPTION
Upstream-worthy improvements developed while building a meeting-challenge benchmark on top of Virtual Community. Each commit is self-contained; rebased on current `master` (incl. the HuggingFace asset-hosting change #22).

## Modules
- **`modules/traffic_manager`: per-vehicle lane tracking.** Replaces the hardcoded `lane_id=-1` fallback with real per-vehicle lane state; adds lane index/successor topology to `localmap` and a `get_next_roads_and_lanes()` helper. `plan`/`act` iterate per-lane. Adds an optional JSON spawn config (`config_path=`) for deterministic vehicle/pedestrian placement in tests and demos.
- **`modules/MapTool`: new routing utility.** A* route planning over a scene's waypoint graph, with `Waypoints`/`RouteNode`/`Route` data classes and bus-schedule integration. Reads scene-config assets via `ASSETS_PATH`, consistent with `env.py`.

## env
- **Wire MapTool as `env.map_tool` + add a `query_map_tool` action** so agents can route through a nav-tool surface (query_place / query_nearby / query_route / query_grid_map / query_grid_map_image / query_refine_route). Responses flow through the existing `EventSystem`.
- **Drop the unused `keystroke_counter` import.** It pulled in `pynput` at import time, which fails on headless compute nodes (no X11 display). The classes were never referenced in `env.py`; user-controlled mode imports them directly where needed.

## tools
- **`tools/road_annotation`:** add `create_opdr.py` (OpenDRIVE generator), `road_stats.py` (per-scene road statistics), and `visualize_osm_roads.py` (road-network renderer; exports `draw_roads()` used by MapTool).
- **`tools/misc/take_avatar_photos`:** emit BGRA with a real alpha channel (transparent background) instead of zero-masking, plus a small brightness boost.